### PR TITLE
fix: Image link and Python version added

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Installation
 
 * Clone the repository: [https://github.com/PelayoAlvarezBrecht/tracer/](https://github.com/PelayoAlvarezBrecht/tracer/)
-* Create and activate a virtual environment:
+* Create and activate a virtual environment  (ensure you're using Python 3.10 or later).
 
   ```bash
   python3 -m venv tracet_env
@@ -18,6 +18,8 @@
   ```bash
   python3 tracET/setup.py install
   ```
+
+The installation has been tested on Ubuntu 22.04, Ubuntu 24.04, and WSL2 (Ubuntu) using Python 3.10.12.
 
 ## Scripts
 
@@ -172,7 +174,7 @@ There are six different scripts used to apply different parts of the process:
   * (Optional) Skeleton of the ground truth tomogram (`-t`, `--ogt`).
 
 ## Tutorials
-In this section we are going to explain how to generate a result from a example data, that we save in the following ![directory](https://zenodo.org/records/13921453).
+In this section we are going to explain how to generate a result from a example data, that we save in the following [directory](https://zenodo.org/records/13921453).
 
 ### Surface example: Membranes
 * In the subdirectory `Membrane` we look at the file `tomo_001_mem_croped.mrc`. In paraview it looks like:


### PR DESCRIPTION
This pull request updates the `README.md` file to improve installation instructions, add compatibility details, and fix a formatting issue in the tutorials section.

### Updates to installation instructions:

* Clarified that Python 3.10 or later is required when creating and activating a virtual environment. (`README.md`, [README.mdL6-R6](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6-R6))
* Added a note specifying that the installation has been tested on Ubuntu 22.04, Ubuntu 24.04, and WSL2 (Ubuntu) with Python 3.10.12. (`README.md`, [README.mdR22-R23](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R22-R23))

### Improvements to tutorial section:

* Fixed a formatting issue by replacing an incorrect image link syntax with a proper hyperlink in the tutorial section. (`README.md`, [README.mdL175-R177](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L175-R177))